### PR TITLE
fix(types): allow falsy values in args

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -11,7 +11,7 @@ interface ResolvedSubprocess extends Omit<ChildProcess, 'stdout' | 'stderr'> {
 
 export interface SubprocessPromise extends Promise<ResolvedSubprocess>, ChildProcess {}
 
-declare function extend(defaults?: ExtendOptions): (input: string, args?: string[] | ExtendOptions, options?: ExtendOptions) => SubprocessPromise;
+declare function extend(defaults?: ExtendOptions): (input: string, args?: (string | false | null | undefined)[] | ExtendOptions, options?: ExtendOptions) => SubprocessPromise;
 
 declare const $: ReturnType<typeof extend> & {
   extend: typeof extend;


### PR DESCRIPTION
Since the args are filtered with `Boolean` constructor, the type definitions should allow falsy values as args.

Note: I did not add `0` as an allowed type. A warning from TypeScript is preferable, since filtering out `0` is likely accidental.