### PR TITLE
feat: add `reject` option

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,11 +2,14 @@ import { ChildProcess, SpawnOptions } from 'child_process';
 
 interface ExtendOptions extends SpawnOptions {
   json?: boolean;
+  reject?: boolean;
 }
 
 interface ResolvedSubprocess extends Omit<ChildProcess, 'stdout' | 'stderr'> {
   stdout: string;
   stderr: string;
+  /** Only exists if `reject` was false and the child process exited with a non-zero code. */
+  error?: Error;
 }
 
 export interface SubprocessPromise extends Promise<ResolvedSubprocess>, ChildProcess {}

--- a/src/index.js
+++ b/src/index.js
@@ -60,9 +60,7 @@ const extend = defaults => (input, args, options) => {
       Object.defineProperty(childProcess, 'stderr', { get: parse(stderr) })
       if (exitCode !== 0) {
         const error = createChildProcessError({ cmd, cmdArgs, childProcess })
-        if (opts.reject !== false) {
-          return reject(error)
-        }
+        if (opts.reject !== false) return reject(error)
         childProcess.error = error
       }
       return resolve(childProcess)

--- a/src/index.js
+++ b/src/index.js
@@ -58,9 +58,14 @@ const extend = defaults => (input, args, options) => {
         get: parse(stdout, opts)
       })
       Object.defineProperty(childProcess, 'stderr', { get: parse(stderr) })
-      return exitCode === 0
-        ? resolve(childProcess)
-        : reject(createChildProcessError({ cmd, cmdArgs, childProcess }))
+      if (exitCode !== 0) {
+        const error = createChildProcessError({ cmd, cmdArgs, childProcess })
+        if (opts.reject !== false) {
+          return reject(error)
+        }
+        childProcess.error = error
+      }
+      return resolve(childProcess)
     })
   })
 

--- a/test/index.js
+++ b/test/index.js
@@ -168,3 +168,17 @@ test('handle stdout/stderr as inherit', async t => {
   t.is(stdout, '')
   t.is(stderr, '')
 })
+
+test('resolve even if exit code is not 0 if reject=false', async t => {
+  const result = await $('exit 1', { reject: false })
+  t.is(result.exitCode, 1)
+  t.is(result.error instanceof Error, true)
+})
+
+test('resolve even if killed if reject=false', async t => {
+  const subprocess = $('sleep 1', { reject: false })
+  subprocess.kill()
+  const result = await subprocess
+  t.is(result.signalCode, 'SIGTERM')
+  t.is(result.error instanceof Error, true)
+})


### PR DESCRIPTION
When `reject: false` is passed, the resolved child process has its `error` property set, rather than rejecting the promise.