### PR TITLE
feat(types): respect `json` option in return type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,24 +1,65 @@
-import { ChildProcess, SpawnOptions } from 'child_process';
+import { ChildProcess, SpawnOptions } from "child_process";
 
-interface ExtendOptions extends SpawnOptions {
+export interface TinyspawnOptions extends SpawnOptions {
   json?: boolean;
   reject?: boolean;
 }
 
-interface ResolvedSubprocess extends Omit<ChildProcess, 'stdout' | 'stderr'> {
-  stdout: string;
+export interface TinyspawnResult<Stdout = string> extends Omit<ChildProcess, "stdout" | "stderr"> {
+  stdout: Stdout;
   stderr: string;
   /** Only exists if `reject` was false and the child process exited with a non-zero code. */
   error?: Error;
 }
 
-export interface SubprocessPromise extends Promise<ResolvedSubprocess>, ChildProcess {}
+export interface TinyspawnPromise<Stdout = string>
+  extends Promise<TinyspawnResult<Stdout>>,
+    ChildProcess {}
 
-declare function extend(defaults?: ExtendOptions): (input: string, args?: (string | false | null | undefined)[] | ExtendOptions, options?: ExtendOptions) => SubprocessPromise;
+export type {
+  /** @deprecated Use `TinyspawnPromise` instead. */
+  TinyspawnPromise as SubprocessPromise,
+};
 
-declare const $: ReturnType<typeof extend> & {
-  extend: typeof extend;
-  json: ReturnType<typeof extend>;
+type Tinyspawn<StdoutDefault> = [StdoutDefault] extends [string]
+  ? {
+      (
+        input: string,
+        args?: (string | false | null | undefined)[],
+        options?: TinyspawnOptions & { json?: false | undefined }
+      ): TinyspawnPromise<string>;
+      (
+        input: string,
+        options?: TinyspawnOptions & { json?: false | undefined }
+      ): TinyspawnPromise<string>;
+      <Stdout = unknown>(
+        input: string,
+        args: (string | false | null | undefined)[],
+        options: TinyspawnOptions & { json: boolean }
+      ): TinyspawnPromise<Stdout>;
+      <Stdout = unknown>(
+        input: string,
+        options: TinyspawnOptions & { json: boolean }
+      ): TinyspawnPromise<Stdout>;
+    }
+  : {
+      (
+        input: string,
+        args: (string | false | null | undefined)[],
+        options: TinyspawnOptions & { json: false }
+      ): TinyspawnPromise<string>;
+      (input: string, options: TinyspawnOptions & { json: false }): TinyspawnPromise<string>;
+      <Stdout = StdoutDefault>(
+        input: string,
+        args?: (string | false | null | undefined)[] | TinyspawnOptions,
+        options?: TinyspawnOptions
+      ): TinyspawnPromise<Stdout>;
+    };
+
+declare const $: Tinyspawn<string> & {
+  extend(defaults?: TinyspawnOptions & { json?: false | undefined }): Tinyspawn<string>;
+  extend(defaults: TinyspawnOptions & { json: boolean }): Tinyspawn<unknown>;
+  json: Tinyspawn<unknown>;
 };
 
 export default $;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -18,7 +18,7 @@ export interface TinyspawnPromise<Stdout = string>
 
 export type {
   /** @deprecated Use `TinyspawnPromise` instead. */
-  TinyspawnPromise as SubprocessPromise,
+  TinyspawnPromise as SubprocessPromise
 }
 
 type Tinyspawn<StdoutDefault> = [StdoutDefault] extends [string]
@@ -26,30 +26,30 @@ type Tinyspawn<StdoutDefault> = [StdoutDefault] extends [string]
       (
         input: string,
         args?: (string | false | null | undefined)[],
-        options?: TinyspawnOptions & { json?: false | undefined },
+        options?: TinyspawnOptions & { json?: false | undefined }
       ): TinyspawnPromise<string>
 
       (
         input: string,
-        options?: TinyspawnOptions & { json?: false | undefined },
+        options?: TinyspawnOptions & { json?: false | undefined }
       ): TinyspawnPromise<string>
 
       <Stdout = unknown>(
         input: string,
         args: (string | false | null | undefined)[] | undefined,
-        options: TinyspawnOptions & { json: boolean },
+        options: TinyspawnOptions & { json: boolean }
       ): TinyspawnPromise<Stdout>
 
       <Stdout = unknown>(
         input: string,
-        options: TinyspawnOptions & { json: boolean },
+        options: TinyspawnOptions & { json: boolean }
       ): TinyspawnPromise<Stdout>
     }
   : {
       (
         input: string,
         args: (string | false | null | undefined)[] | undefined,
-        options: TinyspawnOptions & { json: false },
+        options: TinyspawnOptions & { json: false }
       ): TinyspawnPromise<string>
 
       (input: string, options: TinyspawnOptions & { json: false }): TinyspawnPromise<string>
@@ -57,7 +57,7 @@ type Tinyspawn<StdoutDefault> = [StdoutDefault] extends [string]
       <Stdout = StdoutDefault>(
         input: string,
         args?: (string | false | null | undefined)[] | TinyspawnOptions,
-        options?: TinyspawnOptions,
+        options?: TinyspawnOptions
       ): TinyspawnPromise<Stdout>
     }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,15 +1,15 @@
-import { ChildProcess, SpawnOptions } from "child_process";
+import { ChildProcess, SpawnOptions } from 'child_process'
 
 export interface TinyspawnOptions extends SpawnOptions {
-  json?: boolean;
-  reject?: boolean;
+  json?: boolean
+  reject?: boolean
 }
 
-export interface TinyspawnResult<Stdout = string> extends Omit<ChildProcess, "stdout" | "stderr"> {
-  stdout: Stdout;
-  stderr: string;
+export interface TinyspawnResult<Stdout = string> extends Omit<ChildProcess, 'stdout' | 'stderr'> {
+  stdout: Stdout
+  stderr: string
   /** Only exists if `reject` was false and the child process exited with a non-zero code. */
-  error?: Error;
+  error?: Error
 }
 
 export interface TinyspawnPromise<Stdout = string>
@@ -19,47 +19,52 @@ export interface TinyspawnPromise<Stdout = string>
 export type {
   /** @deprecated Use `TinyspawnPromise` instead. */
   TinyspawnPromise as SubprocessPromise,
-};
+}
 
 type Tinyspawn<StdoutDefault> = [StdoutDefault] extends [string]
   ? {
       (
         input: string,
         args?: (string | false | null | undefined)[],
-        options?: TinyspawnOptions & { json?: false | undefined }
-      ): TinyspawnPromise<string>;
+        options?: TinyspawnOptions & { json?: false | undefined },
+      ): TinyspawnPromise<string>
+
       (
         input: string,
-        options?: TinyspawnOptions & { json?: false | undefined }
-      ): TinyspawnPromise<string>;
+        options?: TinyspawnOptions & { json?: false | undefined },
+      ): TinyspawnPromise<string>
+
       <Stdout = unknown>(
         input: string,
-        args: (string | false | null | undefined)[],
-        options: TinyspawnOptions & { json: boolean }
-      ): TinyspawnPromise<Stdout>;
+        args: (string | false | null | undefined)[] | undefined,
+        options: TinyspawnOptions & { json: boolean },
+      ): TinyspawnPromise<Stdout>
+
       <Stdout = unknown>(
         input: string,
-        options: TinyspawnOptions & { json: boolean }
-      ): TinyspawnPromise<Stdout>;
+        options: TinyspawnOptions & { json: boolean },
+      ): TinyspawnPromise<Stdout>
     }
   : {
       (
         input: string,
-        args: (string | false | null | undefined)[],
-        options: TinyspawnOptions & { json: false }
-      ): TinyspawnPromise<string>;
-      (input: string, options: TinyspawnOptions & { json: false }): TinyspawnPromise<string>;
+        args: (string | false | null | undefined)[] | undefined,
+        options: TinyspawnOptions & { json: false },
+      ): TinyspawnPromise<string>
+
+      (input: string, options: TinyspawnOptions & { json: false }): TinyspawnPromise<string>
+
       <Stdout = StdoutDefault>(
         input: string,
         args?: (string | false | null | undefined)[] | TinyspawnOptions,
-        options?: TinyspawnOptions
-      ): TinyspawnPromise<Stdout>;
-    };
+        options?: TinyspawnOptions,
+      ): TinyspawnPromise<Stdout>
+    }
 
 declare const $: Tinyspawn<string> & {
-  extend(defaults?: TinyspawnOptions & { json?: false | undefined }): Tinyspawn<string>;
-  extend(defaults: TinyspawnOptions & { json: boolean }): Tinyspawn<unknown>;
-  json: Tinyspawn<unknown>;
-};
+  extend(defaults?: TinyspawnOptions & { json?: false | undefined }): Tinyspawn<string>
+  extend(defaults: TinyspawnOptions & { json: boolean }): Tinyspawn<unknown>
+  json: Tinyspawn<unknown>
+}
 
-export default $;
+export default $

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,53 +1,53 @@
-import { expectType } from "tsd";
-import $ from "..";
+import { expectType } from 'tsd'
+import $ from '..'
 
 /* basic */
 
-const promise = $("curl https://www.youtube.com/watch?v=6xKWiCMKKJg");
+const promise = $('curl https://www.youtube.com/watch?v=6xKWiCMKKJg')
 
 // at this point it's a child_process instance
-promise.kill();
-promise.ref();
-promise.unref();
+promise.kill()
+promise.ref()
+promise.unref()
 
-const result = await promise;
+const result = await promise
 
 // after that stdout/stderr are available as string values
 
-console.log(result.stdout);
-console.log(result.stderr);
+console.log(result.stdout)
+console.log(result.stderr)
 
-console.log(result.connected);
-console.log(result.signalCode);
-console.log(result.exitCode);
-console.log(result.killed);
-console.log(result.spawnfile);
-console.log(result.spawnargs);
-console.log(result.pid);
-console.log(result.stdin);
-console.log(result.stdout);
-console.log(result.stderr);
-console.log(result.stdin);
+console.log(result.connected)
+console.log(result.signalCode)
+console.log(result.exitCode)
+console.log(result.killed)
+console.log(result.spawnfile)
+console.log(result.spawnargs)
+console.log(result.pid)
+console.log(result.stdin)
+console.log(result.stdout)
+console.log(result.stderr)
+console.log(result.stdin)
 
 /* json */
 
-const json = await $.json("curl https://geolocation.microlink.io");
-expectType<unknown>(json.stdout);
+const json = await $.json('curl https://geolocation.microlink.io')
+expectType<unknown>(json.stdout)
 
 type Geolocation = {
   ip: {
-    address: string;
-  };
-};
+    address: string
+  }
+}
 
 // Explicit type
-const json2 = await $.json<Geolocation>("curl https://geolocation.microlink.io");
-expectType<Geolocation>(json2.stdout);
+const json2 = await $.json<Geolocation>('curl https://geolocation.microlink.io')
+expectType<Geolocation>(json2.stdout)
 
 // Override json=true option
-const json3 = await $.json("curl https://geolocation.microlink.io", { json: false });
-expectType<string>(json3.stdout);
+const json3 = await $.json('curl https://geolocation.microlink.io', { json: false })
+expectType<string>(json3.stdout)
 
 // When json option might be true or false
-const json4 = await $("curl https://geolocation.microlink.io", { json: {} as boolean });
-expectType<unknown>(json4.stdout);
+const json4 = await $('curl https://geolocation.microlink.io', { json: {} as boolean })
+expectType<unknown>(json4.stdout)

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,29 +1,53 @@
-import $ from '..'
+import { expectType } from "tsd";
+import $ from "..";
 
 /* basic */
 
-const promise = $('curl https://www.youtube.com/watch?v=6xKWiCMKKJg')
+const promise = $("curl https://www.youtube.com/watch?v=6xKWiCMKKJg");
 
 // at this point it's a child_process instance
-promise.kill()
-promise.ref()
-promise.unref()
+promise.kill();
+promise.ref();
+promise.unref();
 
-const result = await promise
+const result = await promise;
 
 // after that stdout/stderr are available as string values
 
-console.log(result.stdout)
-console.log(result.stderr)
+console.log(result.stdout);
+console.log(result.stderr);
 
-console.log(result.connected)
-console.log(result.signalCode)
-console.log(result.exitCode)
-console.log(result.killed)
-console.log(result.spawnfile)
-console.log(result.spawnargs)
-console.log(result.pid)
-console.log(result.stdin)
-console.log(result.stdout)
-console.log(result.stderr)
-console.log(result.stdin)
+console.log(result.connected);
+console.log(result.signalCode);
+console.log(result.exitCode);
+console.log(result.killed);
+console.log(result.spawnfile);
+console.log(result.spawnargs);
+console.log(result.pid);
+console.log(result.stdin);
+console.log(result.stdout);
+console.log(result.stderr);
+console.log(result.stdin);
+
+/* json */
+
+const json = await $.json("curl https://geolocation.microlink.io");
+expectType<unknown>(json.stdout);
+
+type Geolocation = {
+  ip: {
+    address: string;
+  };
+};
+
+// Explicit type
+const json2 = await $.json<Geolocation>("curl https://geolocation.microlink.io");
+expectType<Geolocation>(json2.stdout);
+
+// Override json=true option
+const json3 = await $.json("curl https://geolocation.microlink.io", { json: false });
+expectType<string>(json3.stdout);
+
+// When json option might be true or false
+const json4 = await $("curl https://geolocation.microlink.io", { json: {} as boolean });
+expectType<unknown>(json4.stdout);


### PR DESCRIPTION
Now the `stdout` type can be explicitly set by the caller, when using `json: true`.

```ts
$.json<Geolocation>("curl https://geolocation.microlink.io");
```

Without an explicit type parameter, `stdout` defaults to `unknown`.

Previously, `stdout` was always a string type (in TypeScript).

### Other changes in this PR

- Export more types.
- Rename `SubprocessPromise` to `TinyspawnPromise`, and deprecate the `SubprocessPromise` type (but keep it for now).

### Considerations

I could remove the ability to do `$.json<Foo>(…)` if you think `$.json(…) as TinyspawnPromise<Foo>` is more appropriate.